### PR TITLE
docs: add benchmark test

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ Unit testing can be run in isolation through the command:
 $ docker-compose run --rm app npm run test:scripts
 ```
 
+### Benchmarking
+
+Although not part of the CI test suite, a _Benchmark_ test is available to see how _Queue_ performs
+against a standard array with 1,000,000 items.
+
+The _Benchmark_ test can be run with the following command:
+
+```sh
+$ docker-compose run --rm app npm run test:benchmark
+```
+
+Optionally, the amount of items can be set by passing in the amount to the script:
+
+```sh
+$ docker-compose run --rm app npm run test:benchmark 65535
+```
+
 ## Contributing
 
 Contributions are always welcome, just submit a PR to get the conversation going. Please make sure

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const Benchmark = require('benchmark');
+
+// eslint-disable-next-line import/no-unresolved
+const Stack = require('../lib/index').default;
+
+const suite = new Benchmark.Suite();
+
+const testLength = process.argv[2] || 1000000;
+const stack = new Stack(testLength);
+const array = new Array(testLength);
+
+for (let length = 0; length < testLength; length += 1) {
+  stack.push(length);
+  array.push(length);
+}
+
+process.stdout.write(`\nRunning benchmark with ${testLength} items:\n\n`);
+
+suite
+  .add('Array#pop() ', () => {
+    const a = array.pop();
+    const b = array.pop();
+    const c = array.pop();
+    array.push(a);
+    array.push(b);
+    array.push(c);
+  })
+  .add('Stack#pop() ', () => {
+    const a = stack.pop();
+    const b = stack.pop();
+    const c = stack.pop();
+    stack.push(a);
+    stack.push(b);
+    stack.push(c);
+  })
+  .on('cycle', (event) => {
+    process.stdout.write(`${String(event.target)}\n`);
+  })
+  .on('complete', function complete() {
+    process.stdout.write(`Fastest is ${this.filter('fastest').map('name')}\n`);
+  })
+  .run({ async: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,6 +1964,16 @@
       "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -11041,6 +11051,12 @@
           }
         }
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "0.0.0-development",
   "description": "A JavaScript implementation of the Stack data structure",
   "main": "lib/index.js",
-  "files": ["/lib"],
+  "files": [
+    "/lib"
+  ],
   "scripts": {
     "build": "babel src --out-dir lib --ignore src/**/*.test.js",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "semantic-release": "semantic-release",
     "test": "npm run test:lint && npm run test:vulnerabilities && npm run test:scripts",
+    "test:benchmark": "npm run build && node benchmark/index.js",
     "test:lint": "eslint --ext js .",
     "test:scripts": "jest --config ./jest.config.json --coverage",
     "test:vulnerabilities": "npm audit",
@@ -28,6 +31,7 @@
     "@commitlint/config-conventional": "^7.1.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
+    "benchmark": "^2.1.4",
     "coveralls": "^3.0.2",
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
add benchmark test using `benchmark` npm package (https://www.npmjs.com/package/benchmark)
standard test uses 1,000,000 items
item count can be altered though the first command-line argument